### PR TITLE
fix: vulnerability

### DIFF
--- a/lib/Weibo.js
+++ b/lib/Weibo.js
@@ -1,4 +1,4 @@
-var open = require('open'),
+var open = require('opn'),
     https = require('https'),
     querystring = require('querystring'),
     urlconfig = require('./config/config.json');

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   ],
   "homepage": "https://github.com/Leask/node-weibo",
   "dependencies": {
-	"open": "*"
+    "opn": "^5.5.0"
   }
 }


### PR DESCRIPTION
the npm package `open` is deprecated, and has a `critical` vulunerability.

see https://www.npmjs.com/advisories/663

<img width="666" alt="Screen Shot 2019-03-19 at 3 19 32 PM" src="https://user-images.githubusercontent.com/14276970/54587435-0a7db280-4a5b-11e9-90b8-aee3e7504d85.png">
